### PR TITLE
Update API in docs and fix for a triclinic test

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,15 +1,20 @@
 # This workflows runs when a tagged release is created or it is triggered manually.
+#
 # For more information see:
-# - Python docs: https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
+# - Python docs: https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows
 # - GitHub action: https://github.com/marketplace/actions/pypi-publish
 # - GitHub docs: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
+#
 # The source distribution (sdist) is built with the `build` package
 # (https://pypa-build.readthedocs.io/en/stable/index.html).
+#
 # The sdist is uploaded to:
 # - TestPyPI whenever the workflow is run
 # - PyPI when the current commit is tagged
+#
+# Trusted publishing to PyPI within GitHub without using an API token: https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers
 
-name: Upload to PyPI
+name: Upload package to PyPI
 
 on:
   release:
@@ -20,28 +25,31 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing:
+      id-token: write
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.x'
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install build
+
     - name: Build package
       run: |
         python -m build
+
     - name: Publish package to TestPyPI
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      uses: pypa/gh-action-pypi-publish@release/v1
+      continue-on-error: true
       with:
-        user: __token__
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/
+
     - name: Publish package to PyPI
-      if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Tests
 
 
 on:
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install dependencies
         run: |
@@ -42,11 +42,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.9, '3.10']
+        python-version: ['3.10', '3.11']
         include:
           - os: ubuntu-latest
             python-version: 3.7
-            OLDEST_SUPPORTED_VERSION: true
             DEPENDENCIES: matplotlib==3.3 numba==0.52 numpy==1.19 ray[default]==1.13
             LABEL: -oldest
     steps:
@@ -63,7 +62,7 @@ jobs:
           pip install -U -e .'[tests]'
 
       - name: Install oldest supported version
-        if: ${{ matrix.OLDEST_SUPPORTED_VERSION }}
+        if: contains(matrix.LABEL, 'oldest')
         run: |
           pip install ${{ matrix.DEPENDENCIES }}
 
@@ -83,7 +82,7 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest --cov=pyebsdindex --pyargs pyebsdindex
+          pytest -n 2 --cov=pyebsdindex --pyargs pyebsdindex
 
       - name: Generate line coverage
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest -n 2 --cov=pyebsdindex --pyargs pyebsdindex
+          pytest --cov=pyebsdindex --pyargs pyebsdindex
 
       - name: Generate line coverage
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ dist/
 *.code-workspace
 
 # Line coverage
-.coverage
+.coverage*
 
 # Sphinx
 doc/build

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,4 +1,4 @@
-# ..readthedocs.yaml
+# .readthedocs.yaml
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
@@ -11,9 +11,9 @@ sphinx:
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.11"
 
 # Build doc in all formats (HTML, PDF and ePub)
 formats:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,48 +5,45 @@ Changelog
 All notable changes to PyEBSDIndex will be documented in this file. The format is based
 on `Keep a Changelog <https://keepachangelog.com/en/1.1.0>`_.
 
-Unreleased
-==========
+0.2.0 (2023-08-08)
+==================
 
 Added
 -----
 - Initial support for uncompressed EBSP files from Oxford systems.
-- Significant improvement in the particle swarm optimization for pattern center optimization.
-- Initial support for non-cubic phases. Hexagonal verified with EDAX convention.  Others are untested.
+- Significant improvement in the particle swarm optimization for pattern center
+  optimization.
+- Initial support for non-cubic phases. Hexagonal verified with EDAX convention.
+  Others are untested.
 - Significant improvements in phase differentiation.
 - NLPAR support for Oxford HDF5 and EBSP.
 - Initial support for Oxford .h5oina files
 - Added IPF coloring/legends for hexagonal phases
 - Data output files in .ang and EDAX .oh5 files
-
+- Explicit support for Python 3.11.
 
 Changed
 -------
-- CRITICAL! All ``ebsd_pattern.EBSDPatternFiles.read_data()`` calls will now return TWO arguments.
-  The patterns (same as previous), and an nd.array of the x,y location within the scan of the patterns. The origin is
-  the center of the scan, and reported in microns.
-- ``ebsd_index.index_pats_distributed()`` now will auto optimize the number of patterns processed at a time depending on GPU
-    capability, and is set as the default.
+- CRITICAL! All ``ebsd_pattern.EBSDPatternFiles.read_data()`` calls will now return TWO
+  arguments. The patterns (same as previous), and an nd.array of the x,y location within
+  the scan of the patterns. The origin is the center of the scan, and reported in
+  microns.
+- ``ebsd_index.index_pats_distributed()`` now will auto optimize the number of patterns
+  processed at a time depending on GPU capability, and is set as the default.
 - Updated tutorials for new features.
-
-
-Deprecated
-----------
 
 Removed
 -------
 - Removed requirement for installation of pyswarms.
 - Removed any references to np.floats and replaced with float() or np.float32/64.
+
 Fixed
 -----
 - Radon transform figure when ``verbose=2`` is passed to various indexing methods is now
   plotted in its own figure.
 - Several bug fixes with NLPAR file reading/writing.
-- Complete rewrite of the scheduling for ``ebsd_index.index_pats_distributed()`` function to be compatible
-  with NVIDIA cards.
-
-Security
---------
+- Complete rewrite of the scheduling for ``ebsd_index.index_pats_distributed()``
+  function to be compatible with NVIDIA cards.
 
 0.1.1 (2022-10-25)
 ==================

--- a/doc/reference/index.rst
+++ b/doc/reference/index.rst
@@ -32,3 +32,4 @@ Functionality is inteded to be imported like this:
     ebsd_index
     nlpar
     pcopt
+    tripletvote

--- a/pyebsdindex/_ebsd_index_parallel.py
+++ b/pyebsdindex/_ebsd_index_parallel.py
@@ -168,25 +168,27 @@ def index_pats_distributed(
     bandData : numpy.ndarray
         Band identification data from the Radon transform. Stored
         as a structured numpy array, of dimensions [npoints, nbands].
+
         With fields that include:
-            band ID ('id'),
-            peak max intesensity [used to calculate pattern quality] ('max')
-            nearest integer location of the Radon peak ('maxloc'),
-            nearest neighbor average of the max peak intensity('avemax'),
-            sub-pixel location of the Radon peak ('aveloc'),
-            a metric of the band width ('width'),
-            the theta value of the sub-pixel location on the Radon [lower-left origin] ('theta'),
-            the rho value of the sub-pixel location on the Radon [lower-left origin]('rho'),
-            was the peak detected ('valid'),
-            index for phase number and pole number that indexed to this band('band_match_index')
-            [use the EBSDIndexer method indexer.getmatchedpole(banddata)]
+            - id: band ID
+            - max: peak max intesensity (used to calculate pattern quality)
+            - maxloc: nearest integer location of the Radon peak
+            - avemax: nearest neighbor average of the max peak intensity
+            - aveloc: sub-pixel location of the Radon peak
+            - width: a metric of the band width
+            - theta: the theta value of the sub-pixel location on the Radon (lower-left origin)
+            - rho: the rho value of the sub-pixel location on the Radon (lower-left origin)
+            - valid: was the peak detected
+            - band_match_index: index for phase number and pole number that indexed to this band
+              (use :meth:`~EBSDIndexer.getmatchedpole`)
+
     indexer : EBSDIndexer
         EBSD indexer, returned if ``return_indexer_obj=True``.
 
     Notes
     -----
-    Requires :mod:`ray[default]`. See the :doc:`installation guide
-    </user/installation>` for details.
+    Requires the ``ray[default]`` package. See the :doc:`installation
+    guide </user/installation>` for details.
     """
     starttime = timer()
     pats = None

--- a/pyebsdindex/_ebsd_index_parallel.py
+++ b/pyebsdindex/_ebsd_index_parallel.py
@@ -29,7 +29,6 @@ import os
 import platform
 import logging
 import sys
-import time
 from timeit import default_timer as timer
 
 import numpy as np
@@ -47,7 +46,8 @@ else:
 RAYIPADDRESS = '127.0.0.1'
 OSPLATFORM  = platform.system()
 if OSPLATFORM  == 'Darwin':
-    RAYIPADDRESS = '0.0.0.0' # the localhost address does not work on macOS when on a VPN
+    RAYIPADDRESS = '0.0.0.0'  # the localhost address does not work on macOS when on a VPN
+
 
 def index_pats_distributed(
     patsin=None,
@@ -72,7 +72,7 @@ def index_pats_distributed(
     ebsd_indexer_obj=None,
     keep_log=False,
     gpu_id=None,
-    verbose = 1
+    verbose=0
 ):
     """Index EBSD patterns in parallel.
 
@@ -130,7 +130,8 @@ def index_pats_distributed(
         Number of patterns to index. Default is ``-1``, which will
         index up to the final pattern in ``patsin``.
     chunksize : int, optional
-        If not set. we will make a guess based on the resources available.
+        If not set, we will make a guess based on the resources
+        available.
     ncpu : int, optional
         Number of CPUs to use. Default value is ``-1``, meaning all
         available CPUs will be used.
@@ -144,6 +145,9 @@ def index_pats_distributed(
         Whether to keep the log. Default is ``False``.
     gpu_id : int, optional
         ID of GPU to use if :mod:`pyopencl` is installed.
+    verbose : int, optional
+        0 - no output (default), 1 - timings, 2 - timings and the Radon
+        transform of the first pattern with detected bands highlighted.
 
     Returns
     -------
@@ -165,17 +169,17 @@ def index_pats_distributed(
         Band identification data from the Radon transform. Stored
         as a structured numpy array, of dimensions [npoints, nbands].
         With fields that include:
-                    band ID ('id'), 
-                    peak max intesensity [used to calculate pattern quality] ('max')
-                    nearest integer location of the Radon peak ('maxloc'),
-                    nearest neighbor average of the max peak intensity('avemax'), 
-                    sub-pixel location of the Radon peak ('aveloc'),
-                    a metric of the band width ('width'), 
-                    the theta value of the sub-pixel location on the Radon [lower-left origin] ('theta'), 
-                    the rho value of the sub-pixel location on the Radon [lower-left origin]('rho'),
-                    was the peak detected ('valid'),
-                    index for phase number and pole number that indexed to this band('band_match_index')
-                    [use the EBSDIndexer method indexer.getmatchedpole(banddata)]
+            band ID ('id'),
+            peak max intesensity [used to calculate pattern quality] ('max')
+            nearest integer location of the Radon peak ('maxloc'),
+            nearest neighbor average of the max peak intensity('avemax'),
+            sub-pixel location of the Radon peak ('aveloc'),
+            a metric of the band width ('width'),
+            the theta value of the sub-pixel location on the Radon [lower-left origin] ('theta'),
+            the rho value of the sub-pixel location on the Radon [lower-left origin]('rho'),
+            was the peak detected ('valid'),
+            index for phase number and pole number that indexed to this band('band_match_index')
+            [use the EBSDIndexer method indexer.getmatchedpole(banddata)]
     indexer : EBSDIndexer
         EBSD indexer, returned if ``return_indexer_obj=True``.
 
@@ -613,6 +617,7 @@ def index_pats_distributed(
     else:
         return dataout, banddataout
 
+
 def __optimizegpuchunk__(indexer, ngpupro, gpu_id, clparam):
 
 
@@ -745,6 +750,8 @@ class GPUWorker:
         except:
             gpujob.rate = None
             return "Error", (None, None, gpujob)
+
+
 @ray.remote(num_cpus=1, num_gpus=0)
 class CPUWorker:
     def __init__(self, actorid=0):
@@ -766,6 +773,8 @@ class CPUWorker:
             print(e)
             cpujob.rate = None
             return "Error", (None,None, cpujob)
+
+
 class CPUGPUJob:
     def __init__(self,jobid, pstart, pend, extime=0.0):
         self.jobid = jobid

--- a/pyebsdindex/_ebsd_index_single.py
+++ b/pyebsdindex/_ebsd_index_single.py
@@ -162,18 +162,20 @@ def index_pats(
     bandData : numpy.ndarray
         Band identification data from the Radon transform. Stored
         as a structured numpy array, of dimensions [npoints, nbands].
+
         With fields that include:
-            band ID ('id'),
-            peak max intesensity [used to calculate pattern quality] ('max')
-            nearest integer location of the Radon peak ('maxloc'),
-            nearest neighbor average of the max peak intensity('avemax'),
-            sub-pixel location of the Radon peak ('aveloc'),
-            a metric of the band width ('width'),
-            the theta value of the sub-pixel location on the Radon [lower-left origin] ('theta'),
-            the rho value of the sub-pixel location on the Radon [lower-left origin]('rho'),
-            was the peak detected ('valid'),
-            index for phase number and pole number that indexed to this band('band_match_index')
-            [use the EBSDIndexer method indexer.getmatchedpole(banddata)]
+            - id: band ID
+            - max: peak max intesensity (used to calculate pattern quality)
+            - maxloc: nearest integer location of the Radon peak
+            - avemax: nearest neighbor average of the max peak intensity
+            - aveloc: sub-pixel location of the Radon peak
+            - width: a metric of the band width
+            - theta: the theta value of the sub-pixel location on the Radon (lower-left origin)
+            - rho: the rho value of the sub-pixel location on the Radon (lower-left origin)
+            - valid: was the peak detected
+            - band_match_index: index for phase number and pole number that indexed to this band
+              (use :meth:`~EBSDIndexer.getmatchedpole`)
+
     indexer : EBSDIndexer
         EBSD indexer, returned if ``return_indexer_obj=True``.
     """
@@ -463,18 +465,20 @@ class EBSDIndexer:
         bandData : numpy.ndarray
             Band identification data from the Radon transform. Stored
             as a structured numpy array, of dimensions [npoints, nbands].
+
             With fields that include:
-                band ID ('id'),
-                peak max intesensity [used to calculate pattern quality] ('max')
-                nearest integer location of the Radon peak ('maxloc'),
-                nearest neighbor average of the max peak intensity('avemax'),
-                sub-pixel location of the Radon peak ('aveloc'),
-                a metric of the band width ('width'),
-                the theta value of the sub-pixel location on the Radon [lower-left origin] ('theta'),
-                the rho value of the sub-pixel location on the Radon [lower-left origin]('rho'),
-                was the peak detected ('valid'),
-                index for phase number and pole number that indexed to this band('band_match_index')
-                [use the EBSDIndexer method indexer.getmatchedpole(banddata)]
+                - id: band ID
+                - max: peak max intesensity (used to calculate pattern quality)
+                - maxloc: nearest integer location of the Radon peak
+                - avemax: nearest neighbor average of the max peak intensity
+                - aveloc: sub-pixel location of the Radon peak
+                - width: a metric of the band width
+                - theta: the theta value of the sub-pixel location on the Radon (lower-left origin)
+                - rho: the rho value of the sub-pixel location on the Radon (lower-left origin)
+                - valid: was the peak detected
+                - band_match_index: index for phase number and pole number that indexed to this band
+                  (use :meth:`~EBSDIndexer.getmatchedpole`)
+
         patstart : int
             Starting index of the indexed patterns.
         npats : int
@@ -503,26 +507,30 @@ class EBSDIndexer:
         return indxData, banddata, patstart, npats
 
     def getmatchedpole(self, banddata, float_out=False):
-        """Return the pole from the library that was matched to the detected band.
+        """Return the pole from the library that was matched to the
+        detected band.
 
         Parameters
         ----------
-        banddata : numpy.ndarray, output structured bandata array from
-            ebsd_index.index_pats or ebsd_index.index_pats_distributed.
-        float_out: False[default]/True, optional
-            Default is to return an array of ints with Miller indices.
-            If set to True, then floats, with unit length will be returned in the
-            sample Cartesian reference frame.
-            (length is only valid for cubic systems).
+        banddata : numpy.ndarray
+            Output structured band data array from
+            :meth:`~pyebsdindex.ebsd_index.index_pats` or
+            :meth:`~pyebsdindex.ebsd_index.index_pats_distributed`.
+        float_out : bool, optional
+            Default (False) is to return an array of ints with Miller
+            indices. If set to True, then floats, with unit length, will
+            be returned in the sample Cartesian reference frame.
+            (Length is only valid for cubic systems).
 
         Returns
         -------
-        polesout : numpy.ndarray int
-           The default is an array [npoints, nbands, 3] that contain the Miller
-           indices of the matching pole (note, that hexagonal will also return only
-           three index notation). If the float_out is set to True, then
-           the output will be floating point vectors of length one, within the sample Cartesian
-           reference frame.
+        numpy.ndarray
+            The default is an array [npoints, nbands, 3] that contains
+            the Miller indices (as ints) of the matching pole (note that
+            hexagonal will also return only three-index notation). If
+            the float_out is set to True, then the output will be
+            floating point vectors of length one, within the sample
+            Cartesian reference frame.
         """
         nphases = len(self.phaseLib)
 
@@ -700,6 +708,7 @@ class EBSDIndexer:
             raise ValueError("`self.vendor` unknown")
 
         return quatref2detect
+
 #    def pcCorrect(self, xy=[[0.0, 0.0]]):
 #        # TODO: At somepoint we will put some methods here for
 #        #  correcting the PC depending on the location within the scan.

--- a/pyebsdindex/band_detect.py
+++ b/pyebsdindex/band_detect.py
@@ -345,7 +345,6 @@ class BandDetect():
       print('Band Label Time:', blabeltime)
       print('Total Band Find Time:',tottime)
     if verbose > 1:
-      plt.clf()
 
       if len(rdnConv.shape) == 3:
         im2show = rdnConv[self.padding[0]:-self.padding[0],self.padding[1]:-self.padding[1], -1]

--- a/pyebsdindex/ebsd_index.py
+++ b/pyebsdindex/ebsd_index.py
@@ -26,12 +26,11 @@ from pyebsdindex import _ray_installed
 from pyebsdindex._ebsd_index_single import EBSDIndexer, index_pats
 
 if _ray_installed:
-    from pyebsdindex._ebsd_index_parallel import index_pats_distributed#, IndexerRay
+    from pyebsdindex._ebsd_index_parallel import index_pats_distributed
 
 
 __all__ = [
     "EBSDIndexer",
-    #"IndexerRay",
     "index_pats",
     "index_pats_distributed",
 ]

--- a/pyebsdindex/nlpar.py
+++ b/pyebsdindex/nlpar.py
@@ -77,14 +77,23 @@ class NLPAR:
       self.filepath = Path(fpath)
       self.hdfdatapath = hdf5path
 
+  def setoutfile(self, patternfile, filepath=None):
+    """Set the output file.
 
+    Parameters
+    ----------
+    patternfile
+      Input pattern file object from ebsd_pattern.
+    filepath
+      String.
 
-
-  def setoutfile(self,patternfile, filepath=None):
-    '''patternfile is an input pattern file object from ebsd_pattern.  Filepath is a string.
-    In the future I want to be able to specify the HDF5 data path to store the output data, but that
-    is proving to be a bit of a mess.  For now, a copy of the original HDF5 is made, and the NLPAR patterns will be
-    overwritten on top of the originals. '''
+    Notes
+    -----
+    In the future I want to be able to specify the HDF5 data path to
+    store the output data, but that is proving to be a bit of a mess.
+    For now, a copy of the original HDF5 is made, and the NLPAR patterns
+    will be overwritten on top of the originals.
+    """
     self.filepathout = None
     self.hdfdatapathout = None
     pathtemp = np.atleast_1d(filepath)

--- a/pyebsdindex/opencl/band_detect_cl.py
+++ b/pyebsdindex/opencl/band_detect_cl.py
@@ -152,7 +152,6 @@ class BandDetect(band_detect.BandDetect):
         print('Band Label Time:', blabeltime)
         print('Total Band Find Time:',tottime)
       if verbose > 1:
-        plt.clf()
 
         if len(rdnConvarray.shape) == 3:
           im2show = rdnConvarray[self.padding[0]:-self.padding[0],self.padding[1]:-self.padding[1], -1]
@@ -170,10 +169,16 @@ class BandDetect(band_detect.BandDetect):
         im2show[-rhoMaskTrim:,:] = 0
 
         im2show = np.fliplr(im2show)
-        fig = plt.figure(figsize=(12,4))
-        subrdn = fig.add_subplot(1,2,1, xlim = (0,180), ylim = (-self.rhoMax, self.rhoMax) )
-        subrdn.imshow(im2show, cmap='gray', extent=[0, 180, -self.rhoMax, self.rhoMax],
-                   interpolation='none', zorder=1, aspect='auto')
+        fig = plt.figure(figsize=(12, 4))
+        subrdn = fig.add_subplot(121, xlim=(0, 180), ylim=(-self.rhoMax, self.rhoMax))
+        subrdn.imshow(
+            im2show,
+            cmap='gray',
+            extent=[0, 180, -self.rhoMax, self.rhoMax],
+            interpolation='none',
+            zorder=1,
+            aspect='auto'
+        )
         width = bandData['width'][-1, :]
         width /= width.min()
         width *= 2.0
@@ -183,11 +188,11 @@ class BandDetect(band_detect.BandDetect):
         subrdn.scatter(y=yplt, x=xplt, c='r', s=width, zorder=2)
 
         for pt in range(self.nBands):
-          subrdn.annotate(str(pt + 1),np.squeeze([xplt[pt]+4,yplt[pt]]), color='yellow')
+          subrdn.annotate(str(pt + 1), np.squeeze([xplt[pt] + 4, yplt[pt]]), color='yellow')
         #subrdn.xlim(0,180)
         #subrdn.ylim(-self.rhoMax, self.rhoMax)
-        subpat = fig.add_subplot(1,2,2)
-        subpat.imshow(patterns[-1,:,:], cmap='gray')
+        subpat = fig.add_subplot(122)
+        subpat.imshow(patterns[-1, :, :], cmap='gray')
 
     except Exception as e: # something went wrong - try the CPU
       print(e)

--- a/pyebsdindex/pcopt.py
+++ b/pyebsdindex/pcopt.py
@@ -220,8 +220,8 @@ def optimize_pso(
         optimization is run for each individual pattern, and an array of
         PC values is returned.
     search_limit : float, optional
-        Default is 0.02 for all PC values, and sets the +/- limit for
-        the optimization search.
+        Default is 0.2 for all PC values, and sets the +/- limit for the
+        optimization search.
     nswarmparticles : int, optional
         Number of particles in a swarm. Default is 30.
     pswarmpar : dict, optional

--- a/pyebsdindex/pcopt.py
+++ b/pyebsdindex/pcopt.py
@@ -529,7 +529,7 @@ class PSOOpt():
 
         with multiprocessing.Pool(min(multiprocessing.cpu_count(), self.n_particles)) as pool:
             if verbose >= 1:
-                print('n_particle:', self.n_particles, 'c1:', self.c1, 'c2:', self.c2, 'w:', self.w )
+                print('n_particles:', self.n_particles, 'c1:', self.c1, 'c2:', self.c2, 'w:', self.w )
 
             self.niter = niter
             for iter in range(niter):

--- a/pyebsdindex/pcopt.py
+++ b/pyebsdindex/pcopt.py
@@ -28,7 +28,6 @@ import scipy.optimize as opt
 from timeit import default_timer as timer
 
 
-
 __all__ = [
     "optimize",
     "optimize_pso",
@@ -187,8 +186,17 @@ def optimize(pats, indexer, PC0=None, batch=False):
     return PCoutRet
 
 
-def optimize_pso(pats, indexer, PC0=None, batch=False, search_limit = 0.2,
-                 nswarmparticles=30, pswarmpar=None, niter=50, verbose=1):
+def optimize_pso(
+    pats,
+    indexer,
+    PC0=None,
+    batch=False,
+    search_limit=0.2,
+    nswarmparticles=30,
+    pswarmpar=None,
+    niter=50,
+    verbose=1
+):
     """Optimize pattern center (PC) (PCx, PCy, PCz) in the convention
     of the :attr:`indexer.vendor` with particle swarms.
 
@@ -212,17 +220,23 @@ def optimize_pso(pats, indexer, PC0=None, batch=False, search_limit = 0.2,
         optimization is run for each individual pattern, and an array of
         PC values is returned.
     search_limit : float, optional
-        Default is 0.05 for all PC values, and sets the +/- limit for the optimization search.
+        Default is 0.02 for all PC values, and sets the +/- limit for
+        the optimization search.
+    nswarmparticles : int, optional
+        Number of particles in a swarm. Default is 30.
+    pswarmpar : dict, optional
+        Particle swarm parameters "c1", "c2", and "w" with defaults 3.5,
+        3.5, and 0.8, respectively.
+    niter : int, optional
+        Number of iterations. Default is 50.
+    verbose : int, optional
+        Whether to print the parameters and progress of the
+        optimization (>= 1) or not (< 1). Default is to print.
 
     Returns
     -------
     numpy.ndarray
         Optimized PC.
-
-    Notes
-    -----
-    :mod:`pyswarms` particle swarm algorithm is used with 50 particles,
-    and parameters c1 = 2.05, c2 = 2.05 and w = 0.8.
     """
     banddat = indexer.bandDetectPlan.find_bands(pats)
     npoints, nbands = banddat.shape[:2]

--- a/pyebsdindex/tests/test_tripletvote.py
+++ b/pyebsdindex/tests/test_tripletvote.py
@@ -82,8 +82,10 @@ class TestAddPhase:
         assert phase.spacegroup == 1
         assert np.allclose(phase.latticeparameter, [2, 3, 4, 70, 100, 120])
         assert phase.nband_earlyexit == 5
-        assert np.allclose(phase.polefamilies, hkl)
+        assert phase.npolefamilies == hkl.shape[0] // 2
+        for hkl_i in phase.polefamilies:
+            assert hkl_i in hkl
 
         angles = phase.angpairs["angles"]
-        assert angles.size == 312
+        assert angles.size == 78
         assert np.unique(angles).size == 77

--- a/pyebsdindex/tests/test_tripletvote.py
+++ b/pyebsdindex/tests/test_tripletvote.py
@@ -1,0 +1,49 @@
+# This software was developed by employees of the US Naval Research Laboratory (NRL), an
+# agency of the Federal Government. Pursuant to title 17 section 105 of the United States
+# Code, works of NRL employees are not subject to copyright protection, and this software
+# is in the public domain. PyEBSDIndex is an experimental system. NRL assumes no
+# responsibility whatsoever for its use by other parties, and makes no guarantees,
+# expressed or implied, about its quality, reliability, or any other characteristic. We
+# would appreciate acknowledgment if the software is used. To the extent that NRL may hold
+# copyright in countries other than the United States, you are hereby granted the
+# non-exclusive irrevocable and unconditional right to print, publish, prepare derivative
+# works and distribute this software, in any medium, or authorize others to do so on your
+# behalf, on a royalty-free basis throughout the world. You may improve, modify, and
+# create derivative works of the software or any portion of the software, and you may copy
+# and distribute such modifications or works. Modified works should carry a notice stating
+# that you changed the software and should note the date and nature of any such change.
+# Please explicitly acknowledge the US Naval Research Laboratory as the original source.
+# This software can be redistributed and/or modified freely provided that any derivative
+# works bear some notice that they are derived from it, and any modified versions bear
+# some notice that they have been modified.
+#
+# Author: David Rowenhorst;
+# The US Naval Research Laboratory Date: 21 Aug 2020
+
+import numpy as np
+
+from pyebsdindex import tripletvote
+
+
+class TestAddPhase:
+    def test_add_phase_triclinic(self):
+        reflectors = np.array(
+            [
+                [ 1,  1,  1],
+                [-1, -1, -1],
+                [ 1,  0,  0],
+                [-1,  0,  0],
+            ],
+            dtype=np.int32,
+        )
+        phase = tripletvote.addphase(
+            spacegroup=1,
+            latticeparameter=[2, 3, 4, 70, 100, 120],
+            nband_earlyexit=5,
+            polefamilies=reflectors,
+        )
+
+        assert phase.spacegroup == 1
+        assert np.allclose(phase.latticeparameter, [2, 3, 4, 70, 100, 120])
+        assert phase.nband_earlyexit == 5
+        assert np.allclose(phase.polefamilies, reflectors)

--- a/pyebsdindex/tests/test_tripletvote.py
+++ b/pyebsdindex/tests/test_tripletvote.py
@@ -20,30 +20,70 @@
 # Author: David Rowenhorst;
 # The US Naval Research Laboratory Date: 21 Aug 2020
 
+from itertools import product
+
 import numpy as np
 
 from pyebsdindex import tripletvote
 
 
 class TestAddPhase:
-    def test_add_phase_triclinic(self):
-        reflectors = np.array(
-            [
-                [ 1,  1,  1],
-                [-1, -1, -1],
-                [ 1,  0,  0],
-                [-1,  0,  0],
-            ],
-            dtype=np.int32,
+    def test_add_phase_fcc(self):
+        phase = tripletvote.addphase("FCC")
+        assert np.allclose(
+            phase.polefamilies, [[0, 0, 2], [1, 1, 1], [0, 2, 2], [1, 1, 3]]
         )
+        angles = phase.angpairs["angles"]
+        assert angles.size == 21
+        assert np.unique(angles).size == 17
+
+    def test_add_phase_bcc(self):
+        phase = tripletvote.addphase("BCC")
+        assert np.allclose(
+            phase.polefamilies, [[0, 1, 1], [0, 0, 2], [1, 1, 2], [0, 1, 3]]
+        )
+        angles = phase.angpairs["angles"]
+        assert angles.size == 34
+        assert np.unique(angles).size == 28
+
+    def test_add_phase_hcp(self):
+        phase = tripletvote.addphase("HCP")
+        assert np.allclose(
+            phase.polefamilies,
+            [
+                [1, 0, -1, 0],
+                [0, 0,  0, 2],
+                [1, 0, -1, 1],
+                [1, 0, -1, 2],
+                [1, 1, -2, 0],
+                [1, 0, -1, 3],
+                [1, 1, -2, 2],
+                [2, 0, -2, 1],
+            ]
+        )
+        angles = phase.angpairs["angles"]
+        assert angles.size == 82
+        assert np.unique(angles).size == 74
+
+    def test_add_phase_triclinic(self):
+        # Build our own reflector list
+        hkl = [1, 1, 1]
+        hkl_ranges = [np.arange(-i, i + 1) for i in hkl]
+        hkl = np.asarray(list(product(*hkl_ranges)), dtype=int)
+        hkl = hkl[~np.all(hkl == 0, axis=1)]  # Remove (000)
+
         phase = tripletvote.addphase(
             spacegroup=1,
             latticeparameter=[2, 3, 4, 70, 100, 120],
             nband_earlyexit=5,
-            polefamilies=reflectors,
+            polefamilies=hkl,
         )
 
         assert phase.spacegroup == 1
         assert np.allclose(phase.latticeparameter, [2, 3, 4, 70, 100, 120])
         assert phase.nband_earlyexit == 5
-        assert np.allclose(phase.polefamilies, reflectors)
+        assert np.allclose(phase.polefamilies, hkl)
+
+        angles = phase.angpairs["angles"]
+        assert angles.size == 312
+        assert np.unique(angles).size == 77

--- a/pyebsdindex/tripletvote.py
+++ b/pyebsdindex/tripletvote.py
@@ -1,24 +1,28 @@
-'''This software was developed by employees of the US Naval Research Laboratory (NRL), an
-agency of the Federal Government. Pursuant to title 17 section 105 of the United States
-Code, works of NRL employees are not subject to copyright protection, and this software
-is in the public domain. PyEBSDIndex is an experimental system. NRL assumes no
-responsibility whatsoever for its use by other parties, and makes no guarantees,
-expressed or implied, about its quality, reliability, or any other characteristic. We
-would appreciate acknowledgment if the software is used. To the extent that NRL may hold
-copyright in countries other than the United States, you are hereby granted the
-non-exclusive irrevocable and unconditional right to print, publish, prepare derivative
-works and distribute this software, in any medium, or authorize others to do so on your
-behalf, on a royalty-free basis throughout the world. You may improve, modify, and
-create derivative works of the software or any portion of the software, and you may copy
-and distribute such modifications or works. Modified works should carry a notice stating
-that you changed the software and should note the date and nature of any such change.
-Please explicitly acknowledge the US Naval Research Laboratory as the original source.
-This software can be redistributed and/or modified freely provided that any derivative
-works bear some notice that they are derived from it, and any modified versions bear
-some notice that they have been modified.
+# This software was developed by employees of the US Naval Research Laboratory (NRL), an
+# agency of the Federal Government. Pursuant to title 17 section 105 of the United States
+# Code, works of NRL employees are not subject to copyright protection, and this software
+# is in the public domain. PyEBSDIndex is an experimental system. NRL assumes no
+# responsibility whatsoever for its use by other parties, and makes no guarantees,
+# expressed or implied, about its quality, reliability, or any other characteristic. We
+# would appreciate acknowledgment if the software is used. To the extent that NRL may hold
+# copyright in countries other than the United States, you are hereby granted the
+# non-exclusive irrevocable and unconditional right to print, publish, prepare derivative
+# works and distribute this software, in any medium, or authorize others to do so on your
+# behalf, on a royalty-free basis throughout the world. You may improve, modify, and
+# create derivative works of the software or any portion of the software, and you may copy
+# and distribute such modifications or works. Modified works should carry a notice stating
+# that you changed the software and should note the date and nature of any such change.
+# Please explicitly acknowledge the US Naval Research Laboratory as the original source.
+# This software can be redistributed and/or modified freely provided that any derivative
+# works bear some notice that they are derived from it, and any modified versions bear
+# some notice that they have been modified.
+#
+# Author: David Rowenhorst;
+# The US Naval Research Laboratory Date: 21 Aug 2020
 
-Author: David Rowenhorst;
-The US Naval Research Laboratory Date: 21 Aug 2020'''
+"""Creation of look-up tables from phase information for band
+indexing.
+"""
 
 from os import environ
 from pathlib import PurePath
@@ -31,6 +35,8 @@ import numba
 
 from pyebsdindex import crystal_sym, rotlib, crystallometry
 
+
+__all__ = ["addphase", "BandIndexer"]
 
 RADEG = 180.0/np.pi
 

--- a/pyebsdindex/tripletvote.py
+++ b/pyebsdindex/tripletvote.py
@@ -332,7 +332,7 @@ class BandIndexer():
         ang = np.clip(ang, -1.0, 1.0)
         #sign = (ang >= 0).astype(np.float32) - (ang < 0).astype(np.float32)
         #sign = np.atleast_1d(sign)
-        ang = np.round(np.arccos(ang)*RADEG*100).astype(np.int32) # get the unique angles between the input
+        ang = np.round(np.arccos(np.abs(ang))*RADEG*100).astype(np.int32) # get the unique angles between the input
         ang = np.atleast_1d(ang)
         # pole, and the family poles. Angles within 0.01 deg are taken as the same.
         unqang, argunq = np.unique(ang, return_index=True)

--- a/pyebsdindex/tripletvote.py
+++ b/pyebsdindex/tripletvote.py
@@ -226,7 +226,7 @@ class BandIndexer():
     keep = np.ones(npoles.shape[0], dtype = int)
     dot = np.abs(npoles.dot(npoles.T))
     for i in range(npoles.shape[0]):
-      wh = np.nonzero(dot[i, i+1:] > 0.999)[0]
+      wh = np.nonzero(dot[i, i+1:] > 0.99999)[0]
       if len(wh) > 0:
         keep[i+1+wh] = 0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,3 +12,17 @@ known_excludes =
     doc/build*
     doc/.ipynb_checkpoints/*
     htmlcov/**
+
+[tool:pytest]
+filterwarnings =
+    ignore:Deprecated call to \`pkg_resources:DeprecationWarning
+    ignore:pkg_resources is deprecated as an API:DeprecationWarning
+
+[coverage:run]
+source = pyebsdindex
+omit =
+    setup.py
+relative_files = True
+
+[coverage:report]
+precision = 2

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ extra_feature_requirements = {
         "coverage                       >= 5.0",
         "pytest                         >= 5.4",
         "pytest-cov                     >= 2.8.1",
-        "pytest-xdist",
     ],
     "gpu": [
         "pyopencl",

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ extra_feature_requirements = {
     "tests": [
         "coverage                       >= 5.0",
         "pytest                         >= 5.4",
-        "pytest-cov                     >= 2.8.1"
+        "pytest-cov                     >= 2.8.1",
+        "pytest-xdist",
     ],
     "gpu": [
         "pyopencl",
@@ -61,6 +62,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Development Status :: 4 - Beta",
         "Intended Audience :: Science/Research",
         "License :: Other/Proprietary License",


### PR DESCRIPTION
This PR is made in response to https://github.com/USNavalResearchLaboratory/PyEBSDIndex/pull/47.

Maintenance changes:
* Clean up docstrings already listed in the (public) API reference in the docs
* Explicitly support Python 3.11 (although I believe 0.1.2 can already run with it)
* Use "Trusted publishers" approach instead of API token to upload package to PyPI (see link in the publish.yml file)

---

I've started to test indexing on other crystal systems than cubic. So far I've only tested on Aimo Winkelmann's triclinic pattern published as part of the supplementary material to their tutorial paper from 2016 ("Which way is up?", [doi](https://doi.org/10.1016/j.matchar.2016.04.008)). To index this triclinic pattern with PyEBSDIndex via kikuchipy, I had to change the calculation of angles in the creation of the look-up table from

```python
    ang = np.round(np.arccos(np.abs(ang))*RADEG*100).astype(np.int32) # get the unique angles between the i
```

to

```python
    ang = np.round(np.arccos(ang)*RADEG*100).astype(np.int32) # get the unique angles between the input
```

Otherwise, creation of the look-up table errored. A side-effect of this change is that more angles are left in the look-up tables for the cubic case than before (the only other case I've tested). I could not find another way to solve this though. @drowenhorst-nrl, any thoughts?

The code to create the look-up table I wanted (I've added a similar test in the test suite):

```python
from itertools import product
import numpy as np
from pyebsdindex import tripletvote

# orix.vector.Miller.from_highest_indices
hkl = [1, 1, 1]
hkl_ranges = [np.arange(-i, i + 1) for i in hkl]
hkl = np.asarray(list(product(*hkl_ranges)), dtype=int)
hkl = hkl[~np.all(hkl == 0, axis=1)]  # Remove (000)
hkl = hkl[::-1]  # Make e.g. (111) first instead of (-1-1-1)

phase = tripletvote.addphase(
    spacegroup=1,
    latticeparameter=[2, 3, 4, 70, 100, 120],
    polefamilies=hkl
)
```

These are the relevant figures from the supplementary information with the crystal structure, detector-sample pattern, orientation, and pattern:

![Screenshot_DynamicS_triclinic_22_39_67_085_035_015_70_-7](https://github.com/drowenhorst-nrl/PyEBSDIndex/assets/12139781/60ff36d4-5520-43ed-b583-d86f5ebae100)

![Tri_Example png_output](https://github.com/drowenhorst-nrl/PyEBSDIndex/assets/12139781/b466c759-dbb8-49c8-9fed-53851e09bbe9)

My test using kikuchipy and PyEBSDIndex with the changes in this PR:

```python
import os
from diffpy.structure import Atom, Lattice, Structure
from diffsims.crystallography import ReciprocalLatticeVector
import kikuchipy as kp
import matplotlib.pyplot as plt
import numpy as np
from orix.crystal_map import Phase, PhaseList
from orix.quaternion import Rotation
import skimage.color as skc


# Read pattern
dir_test = "/home/hakon/kode/kikuchipy_test/geometrical_simulations_all_point_groups"
s = kp.signals.EBSD(skc.rgb2gray(plt.imread(os.path.join(dir_test, "Tri_Example.png"))))

# Make detector
detector = kp.detectors.EBSDDetector(
    shape=s.axes_manager.signal_shape[::-1],
    sample_tilt=70,
    tilt=-7,
    pc=(0.35006, 0.15, 0.85),
)

# Define crystal structure
lat = Lattice(2, 3, 4, 70, 100, 120)
phase = Phase(space_group=1, structure=Structure(lattice=lat))

# Make reflector list
ref = ReciprocalLatticeVector.from_highest_hkl(phase, hkl=(1, 1, 1))

# Indexer
phase_list = PhaseList(phase)
indexer = detector.get_indexer(phase_list, ref, tSigma=2, rSigma=2)

xmap = s.hough_indexing(phase_list, indexer, verbose=2)

# Compare solution to Bruker's
rot_bruker = Rotation.from_euler([22, 39, 67], degrees=True)
rot = xmap.rotations
print(rot_bruker.angle_with(rot, degrees=True))
# Output: [85.33466643]

simulator = kp.simulations.KikuchiPatternSimulator(ref)
sim = simulator.on_detector(detector, rot)
sim.plot(pattern=s.data)
```

Output from PyEBSDIndex:

![pyebsdindex_output](https://github.com/drowenhorst-nrl/PyEBSDIndex/assets/12139781/c82ca242-75e2-4469-9543-48de35e54deb)

Output from kikuchipy:

![kp_output](https://github.com/drowenhorst-nrl/PyEBSDIndex/assets/12139781/7b461557-e7c3-4c17-9d85-592240ffd58d)